### PR TITLE
Add minimal backend and Docker setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# LogHub Backend
+
+This repository contains a minimal FastAPI server.
+
+## Build and Run with Docker
+
+```bash
+# Build the Docker image
+docker build -f docker/Dockerfile -t loghub-backend .
+
+# Run the container
+docker run -p 8000:8000 loghub-backend
+```
+
+The server will be available at `http://localhost:8000/` and will respond with `{"message": "Hello World"}`.
+

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,11 @@
+from fastapi import FastAPI
+import uvicorn
+
+app = FastAPI()
+
+@app.get("/")
+async def read_root():
+    return {"message": "Hello World"}
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY ./backend ./backend
+RUN pip install fastapi uvicorn
+EXPOSE 8000
+CMD ["python", "backend/main.py"]


### PR DESCRIPTION
## Summary
- scaffold `backend/` and `docker/` directories
- implement a basic FastAPI app returning "Hello World"
- add a Dockerfile to run the server
- document Docker build and run steps

## Testing
- `python3 -m py_compile backend/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6889371e5bf88328a4827632ad7f2ba9