### PR TITLE
Implement SQLite QSO CRUD

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LogHub Backend
 
-This repository contains a minimal FastAPI server.
+This repository contains a simple FastAPI server with a SQLite database.
 
 ## Build and Run with Docker
 
@@ -12,5 +12,12 @@ docker build -f docker/Dockerfile -t loghub-backend .
 docker run -p 8000:8000 loghub-backend
 ```
 
-The server will be available at `http://localhost:8000/` and will respond with `{"message": "Hello World"}`.
+The server will be available at `http://localhost:8000/` and includes CRUD endpoints for QSO records:
 
+- `POST /qsos` create a QSO
+- `GET /qsos` list QSOs
+- `GET /qsos/{id}` retrieve a QSO
+- `PUT /qsos/{id}` update a QSO
+- `DELETE /qsos/{id}` remove a QSO
+
+All data is stored in a SQLite database file `qso.db` located in the working directory.

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,0 +1,12 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///./qso.db"
+
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,11 +1,71 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Depends, HTTPException
+from sqlalchemy.orm import Session
 import uvicorn
 
+from . import models, schemas
+from .database import SessionLocal, engine
+
+models.Base.metadata.create_all(bind=engine)
+
 app = FastAPI()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
 
 @app.get("/")
 async def read_root():
     return {"message": "Hello World"}
+
+
+@app.post("/qsos", response_model=schemas.QSO)
+def create_qso(qso: schemas.QSOCreate, db: Session = Depends(get_db)):
+    db_qso = models.QSO(**qso.dict())
+    db.add(db_qso)
+    db.commit()
+    db.refresh(db_qso)
+    return db_qso
+
+
+@app.get("/qsos", response_model=list[schemas.QSO])
+def read_qsos(skip: int = 0, limit: int = 100, db: Session = Depends(get_db)):
+    return db.query(models.QSO).offset(skip).limit(limit).all()
+
+
+@app.get("/qsos/{qso_id}", response_model=schemas.QSO)
+def read_qso(qso_id: int, db: Session = Depends(get_db)):
+    qso = db.query(models.QSO).filter(models.QSO.id == qso_id).first()
+    if qso is None:
+        raise HTTPException(status_code=404, detail="QSO not found")
+    return qso
+
+
+@app.put("/qsos/{qso_id}", response_model=schemas.QSO)
+def update_qso(qso_id: int, qso_update: schemas.QSOUpdate, db: Session = Depends(get_db)):
+    qso = db.query(models.QSO).filter(models.QSO.id == qso_id).first()
+    if qso is None:
+        raise HTTPException(status_code=404, detail="QSO not found")
+    for key, value in qso_update.dict(exclude_unset=True).items():
+        setattr(qso, key, value)
+    db.commit()
+    db.refresh(qso)
+    return qso
+
+
+@app.delete("/qsos/{qso_id}")
+def delete_qso(qso_id: int, db: Session = Depends(get_db)):
+    qso = db.query(models.QSO).filter(models.QSO.id == qso_id).first()
+    if qso is None:
+        raise HTTPException(status_code=404, detail="QSO not found")
+    db.delete(qso)
+    db.commit()
+    return {"ok": True}
+
 
 if __name__ == "__main__":
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,13 @@
+from datetime import datetime
+from sqlalchemy import Column, Integer, String, Float, DateTime
+
+from .database import Base
+
+class QSO(Base):
+    __tablename__ = "qsos"
+
+    id = Column(Integer, primary_key=True, index=True)
+    callsign = Column(String, index=True)
+    frequency = Column(Float)
+    mode = Column(String)
+    timestamp = Column(DateTime, default=datetime.utcnow)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+from pydantic import BaseModel
+
+class QSOBase(BaseModel):
+    callsign: str
+    frequency: float
+    mode: str
+    timestamp: datetime | None = None
+
+class QSOCreate(QSOBase):
+    pass
+
+class QSOUpdate(QSOBase):
+    pass
+
+class QSO(QSOBase):
+    id: int
+
+    class Config:
+        orm_mode = True

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.11-slim
 WORKDIR /app
 COPY ./backend ./backend
-RUN pip install fastapi uvicorn
+RUN pip install fastapi uvicorn sqlalchemy
 EXPOSE 8000
-CMD ["python", "backend/main.py"]
+CMD ["python", "-m", "backend.main"]


### PR DESCRIPTION
## Summary
- add SQLAlchemy database layer
- implement QSO model and schema
- provide CRUD endpoints for QSOs
- document API usage in README
- install new deps in Dockerfile

## Testing
- `python -m py_compile backend/main.py backend/database.py backend/models.py backend/schemas.py`
- `python -m backend.main` *(fails: port open then killed)*
- `docker build` *(fails: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68893ac28fd88328ab9d825a7a37d0ce