### PR TITLE
Add service interface modules

### DIFF
--- a/backend/interfaces/__init__.py
+++ b/backend/interfaces/__init__.py
@@ -1,0 +1,6 @@
+"""Interface modules for external QSO services."""
+
+# Expose individual service modules for convenience
+from . import clublog, lotw, ham365, qrz
+
+__all__ = ["clublog", "lotw", "ham365", "qrz"]

--- a/backend/interfaces/clublog.py
+++ b/backend/interfaces/clublog.py
@@ -1,0 +1,22 @@
+"""Club Log service API interface."""
+
+from typing import Dict, List
+import requests
+
+BASE_URL = "https://example.com/clublog"
+
+
+def fetch_qsos(api_key: str) -> List[Dict]:
+    """Fetch QSOs from Club Log via HTTP API."""
+    params = {"api_key": api_key}
+    resp = requests.get(f"{BASE_URL}/qsos", params=params)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def push_qso(api_key: str, qso: Dict) -> Dict:
+    """Push a single QSO record to Club Log."""
+    params = {"api_key": api_key}
+    resp = requests.post(f"{BASE_URL}/qsos", params=params, json=qso)
+    resp.raise_for_status()
+    return resp.json()

--- a/backend/interfaces/ham365.py
+++ b/backend/interfaces/ham365.py
@@ -1,0 +1,22 @@
+"""Ham365 service API interface."""
+
+from typing import Dict, List
+import requests
+
+BASE_URL = "https://example.com/ham365"
+
+
+def fetch_qsos(api_key: str) -> List[Dict]:
+    """Fetch QSOs from Ham365 via HTTP API."""
+    headers = {"Authorization": f"Bearer {api_key}"}
+    resp = requests.get(f"{BASE_URL}/qsos", headers=headers)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def push_qso(api_key: str, qso: Dict) -> Dict:
+    """Push a single QSO record to Ham365."""
+    headers = {"Authorization": f"Bearer {api_key}"}
+    resp = requests.post(f"{BASE_URL}/qsos", headers=headers, json=qso)
+    resp.raise_for_status()
+    return resp.json()

--- a/backend/interfaces/lotw.py
+++ b/backend/interfaces/lotw.py
@@ -1,0 +1,22 @@
+"""LoTW service API interface."""
+
+from typing import Dict, List
+import requests
+
+BASE_URL = "https://example.com/lotw"
+
+
+def fetch_qsos(api_key: str) -> List[Dict]:
+    """Fetch QSOs from LoTW via HTTP API."""
+    headers = {"Authorization": f"Bearer {api_key}"}
+    resp = requests.get(f"{BASE_URL}/qsos", headers=headers)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def push_qso(api_key: str, qso: Dict) -> Dict:
+    """Push a single QSO record to LoTW."""
+    headers = {"Authorization": f"Bearer {api_key}"}
+    resp = requests.post(f"{BASE_URL}/qsos", headers=headers, json=qso)
+    resp.raise_for_status()
+    return resp.json()

--- a/backend/interfaces/qrz.py
+++ b/backend/interfaces/qrz.py
@@ -1,0 +1,27 @@
+"""QRZ.com service API interface."""
+
+from typing import Dict, List
+import requests
+
+BASE_URL = "https://example.com/qrz"
+
+
+def fetch_qsos(username: str, password: str) -> List[Dict]:
+    """Fetch QSOs from QRZ.com via HTTP API."""
+    resp = requests.get(
+        f"{BASE_URL}/qsos",
+        params={"user": username, "password": password},
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def push_qso(username: str, password: str, qso: Dict) -> Dict:
+    """Push a single QSO record to QRZ.com."""
+    resp = requests.post(
+        f"{BASE_URL}/qsos",
+        params={"user": username, "password": password},
+        json=qso,
+    )
+    resp.raise_for_status()
+    return resp.json()

--- a/tests/interfaces/test_clublog.py
+++ b/tests/interfaces/test_clublog.py
@@ -1,0 +1,24 @@
+import os
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+from backend.interfaces import clublog
+
+
+def test_fetch_qsos():
+    with patch('backend.interfaces.clublog.requests.get') as mock_get:
+        mock_get.return_value.json.return_value = [{'id': 1}]
+        mock_get.return_value.raise_for_status.return_value = None
+        result = clublog.fetch_qsos('key')
+        mock_get.assert_called_once()
+        assert result == [{'id': 1}]
+
+
+def test_push_qso():
+    with patch('backend.interfaces.clublog.requests.post') as mock_post:
+        mock_post.return_value.json.return_value = {'status': 'ok'}
+        mock_post.return_value.raise_for_status.return_value = None
+        result = clublog.push_qso('key', {'id': 1})
+        mock_post.assert_called_once()
+        assert result == {'status': 'ok'}

--- a/tests/interfaces/test_ham365.py
+++ b/tests/interfaces/test_ham365.py
@@ -1,0 +1,24 @@
+import os
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+from backend.interfaces import ham365
+
+
+def test_fetch_qsos():
+    with patch('backend.interfaces.ham365.requests.get') as mock_get:
+        mock_get.return_value.json.return_value = [{'id': 1}]
+        mock_get.return_value.raise_for_status.return_value = None
+        result = ham365.fetch_qsos('secret')
+        mock_get.assert_called_once()
+        assert result == [{'id': 1}]
+
+
+def test_push_qso():
+    with patch('backend.interfaces.ham365.requests.post') as mock_post:
+        mock_post.return_value.json.return_value = {'status': 'ok'}
+        mock_post.return_value.raise_for_status.return_value = None
+        result = ham365.push_qso('secret', {'id': 1})
+        mock_post.assert_called_once()
+        assert result == {'status': 'ok'}

--- a/tests/interfaces/test_lotw.py
+++ b/tests/interfaces/test_lotw.py
@@ -1,0 +1,24 @@
+import os
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+from backend.interfaces import lotw
+
+
+def test_fetch_qsos():
+    with patch('backend.interfaces.lotw.requests.get') as mock_get:
+        mock_get.return_value.json.return_value = [{'id': 1}]
+        mock_get.return_value.raise_for_status.return_value = None
+        result = lotw.fetch_qsos('secret')
+        mock_get.assert_called_once()
+        assert result == [{'id': 1}]
+
+
+def test_push_qso():
+    with patch('backend.interfaces.lotw.requests.post') as mock_post:
+        mock_post.return_value.json.return_value = {'status': 'ok'}
+        mock_post.return_value.raise_for_status.return_value = None
+        result = lotw.push_qso('secret', {'id': 1})
+        mock_post.assert_called_once()
+        assert result == {'status': 'ok'}

--- a/tests/interfaces/test_qrz.py
+++ b/tests/interfaces/test_qrz.py
@@ -1,0 +1,24 @@
+import os
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+from backend.interfaces import qrz
+
+
+def test_fetch_qsos():
+    with patch('backend.interfaces.qrz.requests.get') as mock_get:
+        mock_get.return_value.json.return_value = [{'id': 1}]
+        mock_get.return_value.raise_for_status.return_value = None
+        result = qrz.fetch_qsos('user', 'pass')
+        mock_get.assert_called_once()
+        assert result == [{'id': 1}]
+
+
+def test_push_qso():
+    with patch('backend.interfaces.qrz.requests.post') as mock_post:
+        mock_post.return_value.json.return_value = {'status': 'ok'}
+        mock_post.return_value.raise_for_status.return_value = None
+        result = qrz.push_qso('user', 'pass', {'id': 1})
+        mock_post.assert_called_once()
+        assert result == {'status': 'ok'}


### PR DESCRIPTION
## Summary
- add placeholder service modules under `backend/interfaces`
- implement fetch/push routines for Club Log, LoTW, Ham365 and QRZ
- demonstrate usage with basic unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68893ccb62888328b4aaeeab6436a403