### PR TITLE
Rename interfaces to remotes

### DIFF
--- a/backend/remotes/__init__.py
+++ b/backend/remotes/__init__.py
@@ -1,4 +1,4 @@
-"""Interface modules for external QSO services."""
+"""Remote modules for external QSO services."""
 
 # Expose individual service modules for convenience
 from . import clublog, lotw, ham365, qrz

--- a/backend/remotes/clublog.py
+++ b/backend/remotes/clublog.py
@@ -1,4 +1,4 @@
-"""Club Log service API interface."""
+"""Club Log service API remote."""
 
 from typing import Dict, List
 import requests

--- a/backend/remotes/ham365.py
+++ b/backend/remotes/ham365.py
@@ -1,4 +1,4 @@
-"""Ham365 service API interface."""
+"""Ham365 service API remote."""
 
 from typing import Dict, List
 import requests

--- a/backend/remotes/lotw.py
+++ b/backend/remotes/lotw.py
@@ -1,4 +1,4 @@
-"""LoTW service API interface."""
+"""LoTW service API remote."""
 
 from typing import Dict, List
 import requests

--- a/backend/remotes/qrz.py
+++ b/backend/remotes/qrz.py
@@ -1,4 +1,4 @@
-"""QRZ.com service API interface."""
+"""QRZ.com service API remote."""
 
 from typing import Dict, List
 import requests

--- a/tests/remotes/test_clublog.py
+++ b/tests/remotes/test_clublog.py
@@ -3,22 +3,22 @@ import sys
 from unittest.mock import patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
-from backend.interfaces import lotw  # noqa: E402
+from backend.remotes import clublog  # noqa: E402
 
 
 def test_fetch_qsos():
-    with patch('backend.interfaces.lotw.requests.get') as mock_get:
+    with patch('backend.remotes.clublog.requests.get') as mock_get:
         mock_get.return_value.json.return_value = [{'id': 1}]
         mock_get.return_value.raise_for_status.return_value = None
-        result = lotw.fetch_qsos('secret')
+        result = clublog.fetch_qsos('key')
         mock_get.assert_called_once()
         assert result == [{'id': 1}]
 
 
 def test_push_qso():
-    with patch('backend.interfaces.lotw.requests.post') as mock_post:
+    with patch('backend.remotes.clublog.requests.post') as mock_post:
         mock_post.return_value.json.return_value = {'status': 'ok'}
         mock_post.return_value.raise_for_status.return_value = None
-        result = lotw.push_qso('secret', {'id': 1})
+        result = clublog.push_qso('key', {'id': 1})
         mock_post.assert_called_once()
         assert result == {'status': 'ok'}

--- a/tests/remotes/test_ham365.py
+++ b/tests/remotes/test_ham365.py
@@ -3,22 +3,22 @@ import sys
 from unittest.mock import patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
-from backend.interfaces import clublog  # noqa: E402
+from backend.remotes import ham365  # noqa: E402
 
 
 def test_fetch_qsos():
-    with patch('backend.interfaces.clublog.requests.get') as mock_get:
+    with patch('backend.remotes.ham365.requests.get') as mock_get:
         mock_get.return_value.json.return_value = [{'id': 1}]
         mock_get.return_value.raise_for_status.return_value = None
-        result = clublog.fetch_qsos('key')
+        result = ham365.fetch_qsos('secret')
         mock_get.assert_called_once()
         assert result == [{'id': 1}]
 
 
 def test_push_qso():
-    with patch('backend.interfaces.clublog.requests.post') as mock_post:
+    with patch('backend.remotes.ham365.requests.post') as mock_post:
         mock_post.return_value.json.return_value = {'status': 'ok'}
         mock_post.return_value.raise_for_status.return_value = None
-        result = clublog.push_qso('key', {'id': 1})
+        result = ham365.push_qso('secret', {'id': 1})
         mock_post.assert_called_once()
         assert result == {'status': 'ok'}

--- a/tests/remotes/test_lotw.py
+++ b/tests/remotes/test_lotw.py
@@ -3,22 +3,22 @@ import sys
 from unittest.mock import patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
-from backend.interfaces import ham365  # noqa: E402
+from backend.remotes import lotw  # noqa: E402
 
 
 def test_fetch_qsos():
-    with patch('backend.interfaces.ham365.requests.get') as mock_get:
+    with patch('backend.remotes.lotw.requests.get') as mock_get:
         mock_get.return_value.json.return_value = [{'id': 1}]
         mock_get.return_value.raise_for_status.return_value = None
-        result = ham365.fetch_qsos('secret')
+        result = lotw.fetch_qsos('secret')
         mock_get.assert_called_once()
         assert result == [{'id': 1}]
 
 
 def test_push_qso():
-    with patch('backend.interfaces.ham365.requests.post') as mock_post:
+    with patch('backend.remotes.lotw.requests.post') as mock_post:
         mock_post.return_value.json.return_value = {'status': 'ok'}
         mock_post.return_value.raise_for_status.return_value = None
-        result = ham365.push_qso('secret', {'id': 1})
+        result = lotw.push_qso('secret', {'id': 1})
         mock_post.assert_called_once()
         assert result == {'status': 'ok'}

--- a/tests/remotes/test_qrz.py
+++ b/tests/remotes/test_qrz.py
@@ -3,11 +3,11 @@ import sys
 from unittest.mock import patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
-from backend.interfaces import qrz  # noqa: E402
+from backend.remotes import qrz  # noqa: E402
 
 
 def test_fetch_qsos():
-    with patch('backend.interfaces.qrz.requests.get') as mock_get:
+    with patch('backend.remotes.qrz.requests.get') as mock_get:
         mock_get.return_value.json.return_value = [{'id': 1}]
         mock_get.return_value.raise_for_status.return_value = None
         result = qrz.fetch_qsos('user', 'pass')
@@ -16,7 +16,7 @@ def test_fetch_qsos():
 
 
 def test_push_qso():
-    with patch('backend.interfaces.qrz.requests.post') as mock_post:
+    with patch('backend.remotes.qrz.requests.post') as mock_post:
         mock_post.return_value.json.return_value = {'status': 'ok'}
         mock_post.return_value.raise_for_status.return_value = None
         result = qrz.push_qso('user', 'pass', {'id': 1})


### PR DESCRIPTION
## Summary
- rename the `interfaces` package to `remotes`
- adjust docstrings for the new naming
- update tests to import from `backend.remotes`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a254f0e9483288ad1a2ba049df9f7