### PR TITLE
Implement sync_qsos for remote modules

### DIFF
--- a/backend/remotes/clublog.py
+++ b/backend/remotes/clublog.py
@@ -20,3 +20,60 @@ def push_qso(api_key: str, qso: Dict) -> Dict:
     resp = requests.post(f"{BASE_URL}/qsos", params=params, json=qso)
     resp.raise_for_status()
     return resp.json()
+
+
+def sync_qsos(local_session, api_key: str, push: bool = False) -> None:
+    """Synchronize QSOs with Club Log.
+
+    Remote QSOs are fetched via :func:`fetch_qsos` and stored in the
+    ``RemoteQSO`` table. Existing rows (matched by ``id`` and the
+    ``remote`` field) are updated while new ones are inserted.  When the
+    ``push`` flag is provided, all local ``QSO`` entries are pushed using
+    :func:`push_qso`.
+    """
+
+    from sqlalchemy.orm import Session
+
+    from .. import models
+
+    if not isinstance(local_session, Session):
+        raise TypeError("local_session must be a sqlalchemy Session")
+
+    remote_qsos = fetch_qsos(api_key)
+    for data in remote_qsos:
+        qso_id = data.get("id")
+        qso = (
+            local_session.query(models.RemoteQSO)
+            .filter_by(id=qso_id, remote="clublog")
+            .first()
+        )
+        if qso:
+            qso.callsign = data.get("callsign")
+            qso.frequency = data.get("frequency")
+            qso.mode = data.get("mode")
+            qso.timestamp = data.get("timestamp")
+        else:
+            qso = models.RemoteQSO(
+                id=qso_id,
+                remote="clublog",
+                callsign=data.get("callsign"),
+                frequency=data.get("frequency"),
+                mode=data.get("mode"),
+                timestamp=data.get("timestamp"),
+            )
+            local_session.add(qso)
+
+    local_session.commit()
+
+    if push:
+        for local in local_session.query(models.QSO).all():
+            push_qso(
+                api_key,
+                {
+                    "id": local.id,
+                    "callsign": local.callsign,
+                    "frequency": local.frequency,
+                    "mode": local.mode,
+                    "timestamp": local.timestamp,
+                },
+            )

--- a/backend/remotes/ham365.py
+++ b/backend/remotes/ham365.py
@@ -20,3 +20,53 @@ def push_qso(api_key: str, qso: Dict) -> Dict:
     resp = requests.post(f"{BASE_URL}/qsos", headers=headers, json=qso)
     resp.raise_for_status()
     return resp.json()
+
+
+def sync_qsos(local_session, api_key: str, push: bool = False) -> None:
+    """Synchronize QSOs with Ham365."""
+
+    from sqlalchemy.orm import Session
+
+    from .. import models
+
+    if not isinstance(local_session, Session):
+        raise TypeError("local_session must be a sqlalchemy Session")
+
+    remote_qsos = fetch_qsos(api_key)
+    for data in remote_qsos:
+        qso_id = data.get("id")
+        qso = (
+            local_session.query(models.RemoteQSO)
+            .filter_by(id=qso_id, remote="ham365")
+            .first()
+        )
+        if qso:
+            qso.callsign = data.get("callsign")
+            qso.frequency = data.get("frequency")
+            qso.mode = data.get("mode")
+            qso.timestamp = data.get("timestamp")
+        else:
+            qso = models.RemoteQSO(
+                id=qso_id,
+                remote="ham365",
+                callsign=data.get("callsign"),
+                frequency=data.get("frequency"),
+                mode=data.get("mode"),
+                timestamp=data.get("timestamp"),
+            )
+            local_session.add(qso)
+
+    local_session.commit()
+
+    if push:
+        for local in local_session.query(models.QSO).all():
+            push_qso(
+                api_key,
+                {
+                    "id": local.id,
+                    "callsign": local.callsign,
+                    "frequency": local.frequency,
+                    "mode": local.mode,
+                    "timestamp": local.timestamp,
+                },
+            )

--- a/backend/remotes/lotw.py
+++ b/backend/remotes/lotw.py
@@ -20,3 +20,53 @@ def push_qso(api_key: str, qso: Dict) -> Dict:
     resp = requests.post(f"{BASE_URL}/qsos", headers=headers, json=qso)
     resp.raise_for_status()
     return resp.json()
+
+
+def sync_qsos(local_session, api_key: str, push: bool = False) -> None:
+    """Synchronize QSOs with LoTW."""
+
+    from sqlalchemy.orm import Session
+
+    from .. import models
+
+    if not isinstance(local_session, Session):
+        raise TypeError("local_session must be a sqlalchemy Session")
+
+    remote_qsos = fetch_qsos(api_key)
+    for data in remote_qsos:
+        qso_id = data.get("id")
+        qso = (
+            local_session.query(models.RemoteQSO)
+            .filter_by(id=qso_id, remote="lotw")
+            .first()
+        )
+        if qso:
+            qso.callsign = data.get("callsign")
+            qso.frequency = data.get("frequency")
+            qso.mode = data.get("mode")
+            qso.timestamp = data.get("timestamp")
+        else:
+            qso = models.RemoteQSO(
+                id=qso_id,
+                remote="lotw",
+                callsign=data.get("callsign"),
+                frequency=data.get("frequency"),
+                mode=data.get("mode"),
+                timestamp=data.get("timestamp"),
+            )
+            local_session.add(qso)
+
+    local_session.commit()
+
+    if push:
+        for local in local_session.query(models.QSO).all():
+            push_qso(
+                api_key,
+                {
+                    "id": local.id,
+                    "callsign": local.callsign,
+                    "frequency": local.frequency,
+                    "mode": local.mode,
+                    "timestamp": local.timestamp,
+                },
+            )

--- a/backend/remotes/qrz.py
+++ b/backend/remotes/qrz.py
@@ -25,3 +25,54 @@ def push_qso(username: str, password: str, qso: Dict) -> Dict:
     )
     resp.raise_for_status()
     return resp.json()
+
+
+def sync_qsos(local_session, username: str, password: str, push: bool = False) -> None:
+    """Synchronize QSOs with QRZ.com."""
+
+    from sqlalchemy.orm import Session
+
+    from .. import models
+
+    if not isinstance(local_session, Session):
+        raise TypeError("local_session must be a sqlalchemy Session")
+
+    remote_qsos = fetch_qsos(username, password)
+    for data in remote_qsos:
+        qso_id = data.get("id")
+        qso = (
+            local_session.query(models.RemoteQSO)
+            .filter_by(id=qso_id, remote="qrz")
+            .first()
+        )
+        if qso:
+            qso.callsign = data.get("callsign")
+            qso.frequency = data.get("frequency")
+            qso.mode = data.get("mode")
+            qso.timestamp = data.get("timestamp")
+        else:
+            qso = models.RemoteQSO(
+                id=qso_id,
+                remote="qrz",
+                callsign=data.get("callsign"),
+                frequency=data.get("frequency"),
+                mode=data.get("mode"),
+                timestamp=data.get("timestamp"),
+            )
+            local_session.add(qso)
+
+    local_session.commit()
+
+    if push:
+        for local in local_session.query(models.QSO).all():
+            push_qso(
+                username,
+                password,
+                {
+                    "id": local.id,
+                    "callsign": local.callsign,
+                    "frequency": local.frequency,
+                    "mode": local.mode,
+                    "timestamp": local.timestamp,
+                },
+            )


### PR DESCRIPTION
## Summary
- add `sync_qsos` to all remote modules
- handle fetching and storing of remote QSOs in `RemoteQSO`
- optionally push local QSOs back to the remote service

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688a2ae4819c8328bd36393cb519b3a5