### PR TITLE
Add sync endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -2,6 +2,8 @@ from fastapi import FastAPI, Depends, HTTPException
 from sqlalchemy.orm import Session
 import uvicorn
 
+from . import remotes
+
 from . import models, schemas
 from .database import SessionLocal
 
@@ -101,6 +103,52 @@ def delete_qso(
     db.delete(qso)
     db.commit()
     return {"ok": True}
+
+
+@app.post("/sync/{remote_name}")
+def sync_remote(
+    remote_name: str,
+    push: bool = False,
+    api_key: str | None = None,
+    username: str | None = None,
+    password: str | None = None,
+    db: Session = Depends(get_db),
+):
+    """Synchronize QSOs with a remote service."""
+
+    sync_map = {
+        "clublog": remotes.clublog.sync_qsos,
+        "lotw": remotes.lotw.sync_qsos,
+        "ham365": remotes.ham365.sync_qsos,
+        "qrz": remotes.qrz.sync_qsos,
+    }
+
+    if remote_name not in sync_map:
+        raise HTTPException(status_code=404, detail="Unknown remote")
+
+    sync_func = sync_map[remote_name]
+
+    if remote_name in {"clublog", "lotw", "ham365"}:
+        if not api_key:
+            raise HTTPException(status_code=400, detail="api_key required")
+        sync_func(db, api_key, push=push)
+    elif remote_name == "qrz":
+        if not username or not password:
+            raise HTTPException(
+                status_code=400, detail="username and password required"
+            )
+        sync_func(db, username, password, push=push)
+
+    remote_count = (
+        db.query(models.RemoteQSO).filter(models.RemoteQSO.remote == remote_name).count()
+    )
+    local_count = db.query(models.QSO).count()
+
+    return {
+        "remote": remote_name,
+        "remote_qsos": remote_count,
+        "local_qsos": local_count,
+    }
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- support syncing remote QSOs

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688a2d9bec3c8328bf6cb7cf47c0edf8