### PR TITLE
Use remote_id for remote QSO lookups

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from sqlalchemy import Column, Integer, String, Float, DateTime
+from sqlalchemy import Column, Integer, String, Float, DateTime, UniqueConstraint
 
 from .database import Base
 
@@ -9,12 +9,15 @@ class RemoteQSO(Base):
 
     __tablename__ = "remote_qsos"
 
-    id = Column(Integer, primary_key=True, index=True)
+    id = Column(Integer, primary_key=True, autoincrement=True)
     remote = Column(String, index=True)
+    remote_id = Column(Integer, index=True)
     callsign = Column(String, index=True)
     frequency = Column(Float)
     mode = Column(String)
     timestamp = Column(DateTime, default=datetime.utcnow)
+
+    __table_args__ = (UniqueConstraint("remote", "remote_id"),)
 
 
 class QSO(Base):

--- a/backend/remotes/clublog.py
+++ b/backend/remotes/clublog.py
@@ -26,7 +26,7 @@ def sync_qsos(local_session, api_key: str, push: bool = False) -> None:
     """Synchronize QSOs with Club Log.
 
     Remote QSOs are fetched via :func:`fetch_qsos` and stored in the
-    ``RemoteQSO`` table. Existing rows (matched by ``id`` and the
+    ``RemoteQSO`` table. Existing rows (matched by ``remote_id`` and the
     ``remote`` field) are updated while new ones are inserted.  When the
     ``push`` flag is provided, all local ``QSO`` entries are pushed using
     :func:`push_qso`.
@@ -44,7 +44,7 @@ def sync_qsos(local_session, api_key: str, push: bool = False) -> None:
         qso_id = data.get("id")
         qso = (
             local_session.query(models.RemoteQSO)
-            .filter_by(id=qso_id, remote="clublog")
+            .filter_by(remote_id=qso_id, remote="clublog")
             .first()
         )
         if qso:
@@ -54,7 +54,7 @@ def sync_qsos(local_session, api_key: str, push: bool = False) -> None:
             qso.timestamp = data.get("timestamp")
         else:
             qso = models.RemoteQSO(
-                id=qso_id,
+                remote_id=qso_id,
                 remote="clublog",
                 callsign=data.get("callsign"),
                 frequency=data.get("frequency"),

--- a/backend/remotes/ham365.py
+++ b/backend/remotes/ham365.py
@@ -37,7 +37,7 @@ def sync_qsos(local_session, api_key: str, push: bool = False) -> None:
         qso_id = data.get("id")
         qso = (
             local_session.query(models.RemoteQSO)
-            .filter_by(id=qso_id, remote="ham365")
+            .filter_by(remote_id=qso_id, remote="ham365")
             .first()
         )
         if qso:
@@ -47,7 +47,7 @@ def sync_qsos(local_session, api_key: str, push: bool = False) -> None:
             qso.timestamp = data.get("timestamp")
         else:
             qso = models.RemoteQSO(
-                id=qso_id,
+                remote_id=qso_id,
                 remote="ham365",
                 callsign=data.get("callsign"),
                 frequency=data.get("frequency"),

--- a/backend/remotes/lotw.py
+++ b/backend/remotes/lotw.py
@@ -37,7 +37,7 @@ def sync_qsos(local_session, api_key: str, push: bool = False) -> None:
         qso_id = data.get("id")
         qso = (
             local_session.query(models.RemoteQSO)
-            .filter_by(id=qso_id, remote="lotw")
+            .filter_by(remote_id=qso_id, remote="lotw")
             .first()
         )
         if qso:
@@ -47,7 +47,7 @@ def sync_qsos(local_session, api_key: str, push: bool = False) -> None:
             qso.timestamp = data.get("timestamp")
         else:
             qso = models.RemoteQSO(
-                id=qso_id,
+                remote_id=qso_id,
                 remote="lotw",
                 callsign=data.get("callsign"),
                 frequency=data.get("frequency"),

--- a/backend/remotes/qrz.py
+++ b/backend/remotes/qrz.py
@@ -42,7 +42,7 @@ def sync_qsos(local_session, username: str, password: str, push: bool = False) -
         qso_id = data.get("id")
         qso = (
             local_session.query(models.RemoteQSO)
-            .filter_by(id=qso_id, remote="qrz")
+            .filter_by(remote_id=qso_id, remote="qrz")
             .first()
         )
         if qso:
@@ -52,7 +52,7 @@ def sync_qsos(local_session, username: str, password: str, push: bool = False) -
             qso.timestamp = data.get("timestamp")
         else:
             qso = models.RemoteQSO(
-                id=qso_id,
+                remote_id=qso_id,
                 remote="qrz",
                 callsign=data.get("callsign"),
                 frequency=data.get("frequency"),

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -55,6 +55,7 @@ def test_sync_qsos_writes_rows(db_session, module, args, remote):
     rows = db_session.query(models.RemoteQSO).filter_by(remote=remote).all()
     assert len(rows) == 1
     row = rows[0]
+    assert row.remote_id == 1
     assert row.callsign == "TEST"
     assert row.frequency == 14.0
     assert row.mode == "CW"
@@ -65,6 +66,7 @@ def test_sync_qsos_writes_rows(db_session, module, args, remote):
     rows = db_session.query(models.RemoteQSO).filter_by(remote=remote).all()
     assert len(rows) == 1
     row = rows[0]
+    assert row.remote_id == 1
     assert row.callsign == "NEW"
     assert row.frequency == 7.0
     assert row.mode == "SSB"


### PR DESCRIPTION
## Summary
- store a remote service identifier alongside each `RemoteQSO`
- uniquely constrain `(remote, remote_id)` and expose `remote_id` in models
- update all sync logic to query using `remote_id`
- adjust sync tests for the new column

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a88529d888328b44fbec26154eb93