### PR TITLE
Move table initialization to startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,4 @@ The server will be available at `http://localhost:8000/` and includes CRUD endpo
 - `DELETE /qsos/{id}` remove a QSO
 
 All data is stored in a SQLite database file `qso.db` located in the working directory.
+The application creates the required tables automatically on startup.

--- a/backend/database.py
+++ b/backend/database.py
@@ -10,8 +10,3 @@ engine = create_engine(
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 Base = declarative_base()
-
-# Import models and create tables when this module is loaded.
-from . import models  # noqa: E402,F401
-
-Base.metadata.create_all(bind=engine)

--- a/backend/main.py
+++ b/backend/main.py
@@ -5,9 +5,15 @@ import uvicorn
 from . import remotes
 
 from . import models, schemas
-from .database import SessionLocal
+from .database import SessionLocal, engine, Base
 
 app = FastAPI()
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    """Create database tables at application startup."""
+    Base.metadata.create_all(bind=engine)
 
 
 def get_db():


### PR DESCRIPTION
## Summary
- avoid automatic table creation when importing database module
- create tables at FastAPI startup
- document that tables are created on startup

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a9400dfa883289b39a112955e9c11